### PR TITLE
Update server.py to import escape from markupsafe

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from events import EventTable
-from flask import escape
+from markupsafe import escape
 from flask import render_template
 from flask import request
 from flask import send_from_directory


### PR DESCRIPTION
In Jinja 3.1.0 previously deprecated code got removed, so escape should be imported from markupsafe.

https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0